### PR TITLE
feat: anyhow によるエラーハンドリング強化

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +330,7 @@ dependencies = [
 name = "docx2json"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "base64",
  "clap",
  "quick-xml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ name = "docx2json"
 path = "src/main.rs"
 
 [dependencies]
+anyhow = "1"
 zip = "2"
 quick-xml = "0.37"
 serde = { version = "1", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,11 @@ fn main() {
     println!("\nDone: {} succeeded, {} failed.", ok.len(), err.len());
     for (path, e) in err.iter() {
         if let Err(e) = e {
-            eprintln!("  FAILED {}: {}", path.display(), e);
+            eprintln!("  FAILED {}", path.display());
+            // anyhow のエラーチェーンを階層表示
+            for (i, cause) in e.chain().enumerate() {
+                eprintln!("    {}{}", "  ".repeat(i), cause);
+            }
         }
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,15 +1,16 @@
 use std::path::Path;
-use crate::models::Document;
 
-type Error = Box<dyn std::error::Error + Send + Sync>;
+use anyhow::{Context, Result};
+
+use crate::models::Document;
 
 /// DocumentをJSONファイルに書き出す
 /// 出力パスは入力パスの拡張子を .json に置換したもの
-pub fn write_json(doc: &Document, input_path: &Path, output_dir: Option<&Path>) -> Result<(), Error> {
+pub fn write_json(doc: &Document, input_path: &Path, output_dir: Option<&Path>) -> Result<()> {
     let stem = input_path
         .file_stem()
         .and_then(|s| s.to_str())
-        .ok_or("Invalid file name")?;
+        .with_context(|| format!("無効なファイル名: {}", input_path.display()))?;
 
     let out_path = if let Some(dir) = output_dir {
         dir.join(format!("{}.json", stem))
@@ -17,8 +18,10 @@ pub fn write_json(doc: &Document, input_path: &Path, output_dir: Option<&Path>) 
         input_path.with_extension("json")
     };
 
-    let json = serde_json::to_string_pretty(doc)?;
-    std::fs::write(&out_path, json)?;
+    let json = serde_json::to_string_pretty(doc)
+        .context("JSONシリアライズに失敗")?;
+    std::fs::write(&out_path, &json)
+        .with_context(|| format!("ファイルへの書き込みに失敗: {}", out_path.display()))?;
     println!("  -> {}", out_path.display());
     Ok(())
 }

--- a/src/parser/docx.rs
+++ b/src/parser/docx.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::io::{BufReader, Read};
 use std::path::Path;
 
+use anyhow::{Context, Result};
 use base64::Engine;
 use quick_xml::events::Event;
 use quick_xml::reader::Reader;
@@ -10,12 +11,12 @@ use zip::ZipArchive;
 use crate::config::Config;
 use crate::models::{Asset, Document, Section};
 
-type Error = Box<dyn std::error::Error + Send + Sync>;
-
 /// DOCXファイルを解析してDocumentを返す
-pub fn parse(path: &Path, config: &Config) -> Result<Document, Error> {
-    let file = std::fs::File::open(path)?;
-    let mut archive = ZipArchive::new(BufReader::new(file))?;
+pub fn parse(path: &Path, config: &Config) -> Result<Document> {
+    let file = std::fs::File::open(path)
+        .with_context(|| format!("ファイルを開けません: {}", path.display()))?;
+    let mut archive = ZipArchive::new(BufReader::new(file))
+        .context("ZIPアーカイブとして開けません（破損または非DOCXファイルの可能性）")?;
 
     // ファイル名をタイトルとして使用
     let title = path
@@ -25,23 +26,27 @@ pub fn parse(path: &Path, config: &Config) -> Result<Document, Error> {
         .to_string();
 
     // relationships を読み込んで画像パスを解決
-    let rels = parse_rels(&mut archive)?;
+    let rels = parse_rels(&mut archive)
+        .context("リレーションシップファイルのパースに失敗")?;
 
     // 画像データをBase64で取得
-    let images = extract_images(&mut archive, &rels)?;
+    let images = extract_images(&mut archive, &rels)
+        .context("画像の抽出に失敗")?;
 
     // document.xml をパース
-    let xml = read_zip_entry(&mut archive, "word/document.xml")?;
-    let sections = parse_document_xml(&xml, &images, config)?;
+    let xml = read_zip_entry(&mut archive, "word/document.xml")
+        .context("word/document.xml の読み込みに失敗")?;
+    let sections = parse_document_xml(&xml, &images, config)
+        .context("document.xml のパースに失敗")?;
 
     Ok(Document { title, sections })
 }
 
 /// word/_rels/document.xml.rels を解析し、rId -> パスのマップを返す
-fn parse_rels(archive: &mut ZipArchive<BufReader<std::fs::File>>) -> Result<HashMap<String, String>, Error> {
+fn parse_rels(archive: &mut ZipArchive<BufReader<std::fs::File>>) -> Result<HashMap<String, String>> {
     let xml = match read_zip_entry(archive, "word/_rels/document.xml.rels") {
         Ok(s) => s,
-        Err(_) => return Ok(HashMap::new()),
+        Err(_) => return Ok(HashMap::new()), // rels ファイルがない場合は空マップを返す
     };
 
     let mut rels = HashMap::new();
@@ -60,7 +65,7 @@ fn parse_rels(archive: &mut ZipArchive<BufReader<std::fs::File>>) -> Result<Hash
                 }
             }
             Ok(Event::Eof) => break,
-            Err(e) => return Err(e.into()),
+            Err(e) => return Err(anyhow::Error::from(e)),
             _ => {}
         }
     }
@@ -71,7 +76,7 @@ fn parse_rels(archive: &mut ZipArchive<BufReader<std::fs::File>>) -> Result<Hash
 fn extract_images(
     archive: &mut ZipArchive<BufReader<std::fs::File>>,
     rels: &HashMap<String, String>,
-) -> Result<HashMap<String, String>, Error> {
+) -> Result<HashMap<String, String>> {
     let mut images = HashMap::new();
     for (rid, zip_path) in rels {
         if let Ok(mut entry) = archive.by_name(zip_path) {
@@ -85,7 +90,7 @@ fn extract_images(
 }
 
 /// document.xml を走査しセクションツリーを構築する
-fn parse_document_xml(xml: &str, images: &HashMap<String, String>, config: &Config) -> Result<Vec<Section>, Error> {
+fn parse_document_xml(xml: &str, images: &HashMap<String, String>, config: &Config) -> Result<Vec<Section>> {
     let mut reader = Reader::from_str(xml);
     reader.config_mut().trim_text(true);
 
@@ -329,7 +334,8 @@ fn parse_document_xml(xml: &str, images: &HashMap<String, String>, config: &Conf
             }
 
             Ok(Event::Eof) => break,
-            Err(e) => return Err(e.into()),
+            Err(e) => return Err(anyhow::Error::from(e)
+                .context("document.xml のXML読み取り中にエラーが発生")),
             _ => {}
         }
     }
@@ -402,9 +408,11 @@ fn attr_value(e: &quick_xml::events::BytesStart, name: &str) -> Option<String> {
 fn read_zip_entry(
     archive: &mut ZipArchive<BufReader<std::fs::File>>,
     name: &str,
-) -> Result<String, Error> {
-    let mut entry = archive.by_name(name)?;
+) -> Result<String> {
+    let mut entry = archive.by_name(name)
+        .with_context(|| format!("ZIPエントリが見つかりません: {}", name))?;
     let mut buf = String::new();
-    entry.read_to_string(&mut buf)?;
+    entry.read_to_string(&mut buf)
+        .with_context(|| format!("ZIPエントリの読み込みに失敗: {}", name))?;
     Ok(buf)
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2,13 +2,18 @@ pub mod docx;
 pub mod xlsx;
 
 use std::path::Path;
+
+use anyhow::{Context, Result};
+
 use crate::config::Config;
 use crate::models::Document;
 
-pub fn parse_file(path: &Path, config: &Config) -> Result<Document, Box<dyn std::error::Error + Send + Sync>> {
+pub fn parse_file(path: &Path, config: &Config) -> Result<Document> {
     match path.extension().and_then(|e| e.to_str()) {
-        Some("docx") => docx::parse(path, config),
-        Some("xlsx") => xlsx::parse(path),
-        ext => Err(format!("Unsupported file type: {:?}", ext).into()),
+        Some("docx") => docx::parse(path, config)
+            .with_context(|| format!("DOCXパース失敗: {}", path.display())),
+        Some("xlsx") => xlsx::parse(path)
+            .with_context(|| format!("XLSXパース失敗: {}", path.display())),
+        ext => anyhow::bail!("未対応のファイル形式: {:?}", ext),
     }
 }

--- a/src/parser/xlsx.rs
+++ b/src/parser/xlsx.rs
@@ -1,10 +1,11 @@
 use std::path::Path;
+
+use anyhow::Result;
+
 use crate::models::{Document, Section};
 
-type Error = Box<dyn std::error::Error + Send + Sync>;
-
 /// XLSXファイルを解析してDocumentを返す（現在はスタブ実装）
-pub fn parse(path: &Path) -> Result<Document, Error> {
+pub fn parse(path: &Path) -> Result<Document> {
     let title = path
         .file_stem()
         .and_then(|s| s.to_str())


### PR DESCRIPTION
closes #2 (一部: エラーハンドリング強化)

## Summary

- `anyhow` クレートを導入し、全パーサー・出力モジュールのエラー型を `Box<dyn Error>` から `anyhow::Error` に移行
- ファイルオープン・ZIPパース・XMLパース・JSON書き込みの各工程に日本語コンテキストメッセージを付加
- エラー発生時にエラーチェーンを階層表示し、原因を辿りやすく改善

## エラー表示の改善

**変更前:**
```
FAILED /path/to/broken.docx: invalid Zip archive: Could not find EOCD
```

**変更後:**
```
FAILED /path/to/broken.docx
  DOCXパース失敗: /path/to/broken.docx
    ZIPアーカイブとして開けません（破損または非DOCXファイルの可能性）
      invalid Zip archive: Could not find EOCD
```

## 変更ファイル

| ファイル | 変更内容 |
| --- | --- |
| `Cargo.toml` | `anyhow = "1"` を追加 |
| `src/parser/mod.rs` | `anyhow::Result` に移行、ファイルパスのコンテキストを付加 |
| `src/parser/docx.rs` | `anyhow::Result` に移行、各工程にコンテキストを付加 |
| `src/parser/xlsx.rs` | `anyhow::Result` に移行 |
| `src/output.rs` | `anyhow::Result` に移行、書き込み先パスのコンテキストを付加 |
| `src/main.rs` | `e.chain()` でエラーチェーンを階層表示 |

## Test plan

- [x] `cargo build` 警告ゼロで成功
- [x] 正常ファイルで既存動作に変化なし（succeeded/failed 件数が同一）
- [x] 破損ファイル投入時にエラーチェーンが階層表示されることを確認
- [x] 破損ファイルがあっても他ファイルの並列処理が継続することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)