### PR TITLE
feat: セクション単位のチャンク分割 --split オプション（ロードマップ #7）

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ AIによる文書解析（RAGや要約）の精度を最大化するため、単
 | **設定ファイルによる見出し制御** | ✅ | `docx2json.json` で見出し検出方法をカスタマイズ可能。 |
 | **箇条書きのMarkdown化** | ✅ | `w:numPr` を検知し `- ` / `1. ` 形式に変換。`word/numbering.xml` を参照し番号付き・箇条書きを判別。インデントレベル（`w:ilvl`）に応じてネストを表現。 |
 | **RAG最適化（context_path）** | ✅ | 各セクションにルートから自身への見出しパスリスト（`context_path`）を付与。チャンク分割後も文書内の位置をAIが把握可能。 |
+| **セクション単位のチャンク分割** | ✅ | `--split <level>` で指定した深さ（1=最上位）でセクションを分割し、セクションごとに個別 JSON を出力。子セクションの本文は Markdown 見出しとして統合。 |
 | **AI連携フォーマッティング** | 🚧 | `--features ai` で有効化。API呼び出しは未実装。 |
 | **XLSXパース** | 🚧 | 構造のみ実装済み、本実装は今後の対応。 |
 
@@ -40,7 +41,7 @@ AIによる文書解析（RAGや要約）の精度を最大化するため、単
 | 4 | **画像メタデータ抽出** | ✅ | `wp:docPr` の `descr`（代替テキスト優先）/ `name` を `Asset.title` に格納。AIが画像の意味を把握可能に |
 | 5 | **箇条書きのMarkdown化** | ✅ | `w:numPr` を検知し `- ` / `1. ` 形式に変換。`numbering.xml` を参照して番号付き・箇条書きを判別。`w:ilvl` のインデントレベルに応じてネストを表現 |
 | 6 | **RAG最適化（context_path）** | ✅ | 各セクションにルートから自身への見出しパスリスト（`context_path`）を付与。チャンク分割後も文書内の位置を保持 |
-| 7 | **セクション単位のチャンク分割** | 🔲 | `--split` オプションで指定レベルごとに個別JSONを出力 |
+| 7 | **セクション単位のチャンク分割** | ✅ | `--split <level>` で指定した深さでセクションを分割し個別 JSON を出力。子セクションは Markdown 見出しとして本文に統合。`source` / `context_path` を保持 |
 | 8 | **画像リサイズ・圧縮** | 🔲 | `image` クレートで高解像度画像をリサイズ（例: 1024px, JPEG 80%）してからBase64化。JSON肥大化を防止 |
 
 ### 🟢 優先度：低（拡張・特殊対応）
@@ -91,6 +92,12 @@ cargo run -- --input ./docs --config ./my-config.json
 
 # AI変換あり（ANTHROPIC_API_KEY 環境変数が必要）
 cargo run --features ai -- --input ./docs --ai
+
+# チャンク分割（最上位セクション単位で個別 JSON を出力）
+cargo run -- --input ./docs --output ./out --split 1
+
+# チャンク分割（2階層目単位で細かく分割）
+cargo run -- --input ./docs --output ./out --split 2
 ```
 
 ## ⚙️ 設定ファイル（`docx2json.json`）

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod models;
 mod output;
 mod parser;
+mod splitter;
 
 use std::path::PathBuf;
 
@@ -27,6 +28,11 @@ struct Cli {
     /// 設定ファイルのパス（省略時は入力ディレクトリ内の docx2json.json を自動検索）
     #[arg(long)]
     config: Option<PathBuf>,
+
+    /// セクション単位のチャンク分割: 指定した深さ（1 = 最上位）でセクションを分割し
+    /// セクションごとに個別 JSON ファイルを出力する（RAG 向け）
+    #[arg(long, value_name = "LEVEL")]
+    split: Option<usize>,
 }
 
 fn main() {
@@ -64,7 +70,13 @@ fn main() {
             println!("Parsing: {}", path.display());
             let result = parser::parse_file(path, &cfg)
                 .map(|doc| if cli.ai { ai::transform(doc) } else { doc })
-                .and_then(|doc| output::write_json(&doc, path, cli.output.as_deref()));
+                .and_then(|doc| {
+                    if let Some(level) = cli.split {
+                        splitter::write_chunks(&doc, path, cli.output.as_deref(), level)
+                    } else {
+                        output::write_json(&doc, path, cli.output.as_deref())
+                    }
+                });
             (path, result)
         })
         .collect();

--- a/src/splitter.rs
+++ b/src/splitter.rs
@@ -1,0 +1,140 @@
+/// RAG向けチャンク分割
+///
+/// セクションツリーを指定した深さで分割し、各チャンクを個別 JSON ファイルとして出力する。
+/// 子セクションの本文は Markdown 見出しとして上位チャンクに統合される。
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+use crate::models::{Asset, Document, Section};
+
+/// 分割後の単一チャンク（RAG インジェスト向けフラット構造）
+#[derive(Debug, Serialize)]
+pub struct Chunk {
+    /// 元のドキュメントタイトル（ファイル名）
+    pub source: String,
+    /// ルートから自身への見出しパスリスト
+    pub context_path: Vec<String>,
+    /// このチャンクのトップ見出し
+    pub heading: String,
+    /// 子セクションの本文を Markdown 見出しとして統合済みの本文
+    pub body_text: String,
+    /// 子セクションのアセットを含む全アセット
+    pub assets: Vec<Asset>,
+}
+
+/// Document をチャンクに分割して個別 JSON ファイルへ書き出す
+///
+/// # 引数
+/// - `split_level`: 分割する深さ（1 = 最上位セクション単位、2 = 2階層目単位、…）
+///   指定した深さに満たないリーフセクションは深さに関わらずチャンク化される
+pub fn write_chunks(
+    doc: &Document,
+    input_path: &Path,
+    output_dir: Option<&Path>,
+    split_level: usize,
+) -> Result<()> {
+    let stem = input_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("output");
+
+    let chunks = collect_chunks(&doc.sections, &doc.title, split_level, 1);
+    let total = chunks.len();
+
+    if total == 0 {
+        println!("  (チャンクなし: セクションが存在しません)");
+        return Ok(());
+    }
+
+    for (i, chunk) in chunks.iter().enumerate() {
+        let filename = format!("{}_chunk_{:03}.json", stem, i + 1);
+        let out_path = if let Some(dir) = output_dir {
+            dir.join(&filename)
+        } else {
+            input_path
+                .parent()
+                .unwrap_or(Path::new("."))
+                .join(&filename)
+        };
+
+        let json = serde_json::to_string_pretty(chunk)
+            .context("チャンクのJSONシリアライズに失敗")?;
+        std::fs::write(&out_path, &json)
+            .with_context(|| format!("チャンクファイルへの書き込みに失敗: {}", out_path.display()))?;
+        println!("  -> {} ({}/{})", out_path.display(), i + 1, total);
+    }
+
+    Ok(())
+}
+
+/// セクションツリーを再帰的に走査し、指定深さのチャンクを収集する
+///
+/// `current_depth >= split_level` または葉ノード（children が空）のセクションを
+/// チャンク化の起点とする。その配下の子セクションは `flatten_into` で本文に統合する。
+fn collect_chunks(
+    sections: &[Section],
+    source: &str,
+    split_level: usize,
+    current_depth: usize,
+) -> Vec<Chunk> {
+    let mut chunks = Vec::new();
+    for section in sections {
+        if current_depth >= split_level || section.children.is_empty() {
+            // このセクションをチャンクの起点とする
+            let mut body_text = section.body_text.clone();
+            let mut assets = section.assets.clone();
+            // 子セクションを Markdown 見出し付きで body_text に統合
+            flatten_into(&section.children, &mut body_text, &mut assets, 2);
+            chunks.push(Chunk {
+                source: source.to_string(),
+                context_path: section.context_path.clone(),
+                heading: section.heading.clone(),
+                body_text,
+                assets,
+            });
+        } else {
+            // まだ目標の深さに達していない: 子を再帰的に収集
+            chunks.extend(collect_chunks(
+                &section.children,
+                source,
+                split_level,
+                current_depth + 1,
+            ));
+        }
+    }
+    chunks
+}
+
+/// セクションリストを再帰的に走査して body_text・assets に平坦化する
+///
+/// 各セクションの見出しは Markdown 見出し記法（## / ### …）で挿入する
+fn flatten_into(
+    sections: &[Section],
+    body_text: &mut String,
+    assets: &mut Vec<Asset>,
+    heading_depth: usize,
+) {
+    for section in sections {
+        // 見出しを Markdown 形式で挿入
+        if !section.heading.is_empty() {
+            let hashes = "#".repeat(heading_depth.min(6));
+            if !body_text.is_empty() {
+                body_text.push('\n');
+            }
+            body_text.push_str(&format!("\n{} {}\n", hashes, section.heading));
+        }
+        // 本文を追記
+        if !section.body_text.is_empty() {
+            if !body_text.is_empty() && !body_text.ends_with('\n') {
+                body_text.push('\n');
+            }
+            body_text.push_str(&section.body_text);
+        }
+        // アセットを収集
+        assets.extend_from_slice(&section.assets);
+        // 孫以下を再帰的に処理
+        flatten_into(&section.children, body_text, assets, heading_depth + 1);
+    }
+}


### PR DESCRIPTION
## 概要

`--split <level>` オプションを追加し、文書をセクション単位に分割して個別 JSON ファイルとして出力できるようにしました。RAG 用のチャンク作成に使用できます。

## 変更内容

### `src/splitter.rs`（新規）

- **`Chunk` 構造体** — RAG インジェスト向けのフラット形式
  - `source`: 元のドキュメントタイトル
  - `context_path`: ルートから自身への見出しパスリスト（#6 で実装済み）
  - `heading` / `body_text` / `assets`
- **`collect_chunks(sections, source, split_level, depth)`**
  - `depth >= split_level` または葉ノードのセクションをチャンクの起点とする
  - 指定深さに達しない葉セクションも必ずチャンク化（サイレントドロップなし）
- **`flatten_into(children, body_text, assets, heading_depth)`**
  - 子セクションを再帰的に走査し、見出しを `##` / `###` … 形式で本文に統合
- **`write_chunks(doc, path, output_dir, level)`**
  - チャンクを `<stem>_chunk_NNN.json` として出力ディレクトリへ書き出し

### `src/main.rs`

- `mod splitter` を追加
- `--split <LEVEL>` オプションを追加（`usize`、省略時は通常の単一 JSON 出力）
- `--split` 指定時は `splitter::write_chunks()`、省略時は `output::write_json()` にルーティング

### `README.md`

- 実装済み機能テーブルに「セクション単位のチャンク分割」を追加（✅）
- ロードマップ優先度中 #7 のステータスを ✅ に更新
- ビルド & 実行例に `--split` の使い方を追記

## 動作仕様

| オプション | 出力 |
| :--- | :--- |
| なし | `<stem>.json`（従来通り） |
| `--split 1` | `<stem>_chunk_001.json` … 最上位セクション単位 |
| `--split 2` | `<stem>_chunk_001.json` … 2階層目単位（より細かく） |

## チャンク JSON の例

```json
{
  "source": "システム機能定義書",
  "context_path": ["２　委託内容", "2.1　委託する作業の内容"],
  "heading": "2.1　委託する作業の内容",
  "body_text": "委託内容は以下のとおり。\n...",
  "assets": []
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)