### PR TITLE
feat: ロードマップ #3 XLSXパース本実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,13 @@ AIによる文書解析（RAGや要約）の精度を最大化するため、単
 | **OMML数式のLaTeX変換** | ✅ | `m:oMath` を検知し `$...$` 形式で埋め込み。分数（`\frac{}`）・上付き（`^{}`）・下付き（`_{}`）・平方根（`\sqrt{}`）を LaTeX に変換。 |
 | **見出し検出の柔軟化** | ✅ | `heading_styles` キーに `"prefix:<str>"` / `"regex:<pattern>"` 記法で前方一致・正規表現マッチを指定可能。 |
 | **進捗表示（CLI）** | ✅ | `indicatif` によるアニメーションプログレスバー。経過時間・処理中ファイル名をリアルタイム表示。完了後に成功/失敗の一覧を出力。 |
+| **XLSXパース本実装** | ✅ | シート名を `heading`、内容をMarkdownテーブルとして `body_text` に格納。Shared Strings・リッチテキスト対応。行数上限（`xlsx_max_rows`）超過時はヘッダーを保持したまま子Sectionに分割。 |
 | **AI連携フォーマッティング** | 🚧 | `--features ai` で有効化。API呼び出しは未実装。 |
-| **XLSXパース** | 🚧 | 構造のみ実装済み、本実装は今後の対応。 |
 
 ## 🗺 ロードマップ（残タスク）
 
 | # | 機能 | 状態 | 概要 |
 | :- | :--- | :---: | :--- |
-| 3 | **XLSXパース本実装** | 🚧 | シート名を `heading`、内容をMarkdownテーブルとして `body_text` に格納。Shared Strings対応 |
 | 9 | **PPTXパース** | 🔲 | スライド単位で `Section` 化。テキストボックスを座標順に結合、スライドノートを補足コンテキストとして抽出 |
 | 10 | **神エクセル対応** | 🔲 | セル結合解決、書式ベースの見出し判定、浮遊テキストボックス抽出 |
 
@@ -89,6 +88,12 @@ cargo run -- --input ./docs --output ./out --image-max-px 1024
 
 # 画像リサイズ + 品質指定
 cargo run -- --input ./docs --output ./out --image-max-px 512 --image-quality 70
+
+# XLSXの大きな表を100行ずつ子Sectionに分割
+cargo run -- --input ./sheets --output ./out --xlsx-max-rows 100
+
+# XLSX分割 + --split 2 でチャンクごとに個別JSONファイルを出力（RAG向け）
+cargo run -- --input ./sheets --output ./out --xlsx-max-rows 100 --split 2
 ```
 
 ## ⚙️ 設定ファイル（`docx2json.json`）
@@ -111,7 +116,8 @@ cargo run -- --input ./docs --output ./out --image-max-px 512 --image-quality 70
   "ppr_underline_as_heading": true,
   "run_underline_as_heading": false,
   "image_max_px": 1024,
-  "image_quality": 80
+  "image_quality": 80,
+  "xlsx_max_rows": 100
 }
 ```
 
@@ -124,6 +130,7 @@ cargo run -- --input ./docs --output ./out --image-max-px 512 --image-quality 70
 | `run_underline_as_heading` | `false` | ランレベル（`w:r > w:rPr`）の下線を見出しとして扱う。Wordの「見出し」スタイルを使わず直接書式で見出しを表現した文書向け。 |
 | `image_max_px` | `0`（無効） | 画像の最大辺長（px）。超過する画像をリサイズし JPEG 再エンコード。`--image-max-px` CLI 引数が優先。 |
 | `image_quality` | `80` | JPEG 再エンコード品質（1〜100）。`image_max_px > 0` のときのみ有効。`--image-quality` CLI 引数が優先。 |
+| `xlsx_max_rows` | `0`（無効） | XLSXシートの最大データ行数。超過した場合ヘッダー行を引き継いだ子Sectionに分割。`--xlsx-max-rows` CLI 引数が優先。 |
 
 ### `heading_styles` キー記法（#12）
 
@@ -185,5 +192,5 @@ src/
 └── parser/
     ├── mod.rs     # ファイル種別ルーティング
     ├── docx.rs    # DOCXパーサー（実装済み）
-    └── xlsx.rs    # XLSXパーサー（スタブ → 実装予定）
+    └── xlsx.rs    # XLSXパーサー（Shared Strings・行チャンク分割対応）
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,12 @@ pub struct Config {
     #[serde(default = "default_image_quality")]
     pub image_quality: u8,
 
+    /// XLSX 1シートあたりの最大データ行数（ヘッダー行を除く）。
+    /// 超過した場合、ヘッダー行を引き継いだ子 Section に分割する。
+    /// 0 = 制限なし（デフォルト）。`--xlsx-max-rows` CLI 引数が優先。
+    #[serde(default)]
+    pub xlsx_max_rows: usize,
+
     /// ロード時にコンパイル済みのマッチングルール群（serde には含まない）
     #[serde(skip)]
     heading_rules: Vec<HeadingRule>,
@@ -82,6 +88,7 @@ impl Default for Config {
             run_underline_as_heading: false, // デフォルトはオフ（誤検出防止）
             image_max_px: 0,
             image_quality: 80,
+            xlsx_max_rows: 0,
             heading_rules: Vec::new(),
         };
         cfg.heading_rules = compile_heading_rules(&cfg.heading_styles);

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,12 @@ struct Cli {
     /// 省略時は設定ファイルの image_quality（デフォルト 80）を使用。
     #[arg(long, value_name = "QUALITY")]
     image_quality: Option<u8>,
+
+    /// XLSX 1シートあたりの最大データ行数。超過した場合ヘッダーを引き継いだ
+    /// 子 Section に分割する（RAG チャンク化）。省略時は設定ファイルの
+    /// xlsx_max_rows（デフォルト 0 = 制限なし）を使用。
+    #[arg(long, value_name = "ROWS")]
+    xlsx_max_rows: Option<usize>,
 }
 
 fn main() {
@@ -56,9 +62,10 @@ fn main() {
         cli.input.clone()
     };
     let mut cfg = config::Config::load(cli.config.as_deref(), &input_dir);
-    // CLI 引数で画像設定を上書き（設定ファイルより優先）
-    if let Some(px) = cli.image_max_px { cfg.image_max_px = px; }
-    if let Some(q) = cli.image_quality  { cfg.image_quality = q.clamp(1, 100); }
+    // CLI 引数で設定を上書き（設定ファイルより優先）
+    if let Some(px) = cli.image_max_px    { cfg.image_max_px = px; }
+    if let Some(q)  = cli.image_quality   { cfg.image_quality = q.clamp(1, 100); }
+    if let Some(r)  = cli.xlsx_max_rows   { cfg.xlsx_max_rows = r; }
 
     // 出力ディレクトリを作成
     if let Some(ref out) = cli.output {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -12,7 +12,7 @@ pub fn parse_file(path: &Path, config: &Config) -> Result<Document> {
     let mut doc = match path.extension().and_then(|e| e.to_str()) {
         Some("docx") => docx::parse(path, config)
             .with_context(|| format!("DOCXパース失敗: {}", path.display()))?,
-        Some("xlsx") => xlsx::parse(path)
+        Some("xlsx") => xlsx::parse(path, config)
             .with_context(|| format!("XLSXパース失敗: {}", path.display()))?,
         ext => anyhow::bail!("未対応のファイル形式: {:?}", ext),
     };

--- a/src/parser/xlsx.rs
+++ b/src/parser/xlsx.rs
@@ -1,31 +1,439 @@
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::Read;
 use std::path::Path;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
+use quick_xml::events::Event;
+use quick_xml::Reader;
+use zip::ZipArchive;
 
+use crate::config::Config;
 use crate::models::{Document, Section};
 
-/// XLSXファイルを解析してDocumentを返す（現在はスタブ実装）
-pub fn parse(path: &Path) -> Result<Document> {
+/// XLSXファイルを解析してDocumentを返す
+///
+/// 各シートを1つのSectionに変換する。シートのデータ行数が `config.xlsx_max_rows` を
+/// 超える場合、ヘッダー行を保持したまま子Sectionに分割する。
+pub fn parse(path: &Path, config: &Config) -> Result<Document> {
     let title = path
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or("Untitled")
         .to_string();
 
-    // TODO: XLSXパーサーの本実装
-    // 1. ZIPを展開して xl/workbook.xml からシート名を取得
-    // 2. xl/worksheets/sheet*.xml を走査してセル値を取得
-    // 3. 各シートを Section として構造化
-    let section = Section {
-        context_path: Vec::new(), // fill_context_path() で後から設定
-        heading: format!("(XLSX stub: {})", title),
-        body_text: "XLSXパーサーは未実装です。".to_string(),
-        assets: Vec::new(),
-        children: Vec::new(),
-    };
+    let file = File::open(path)
+        .with_context(|| format!("ファイルを開けません: {}", path.display()))?;
+    let mut archive = ZipArchive::new(file).context("ZIPアーカイブとして開けません")?;
 
-    Ok(Document {
-        title,
-        sections: vec![section],
-    })
+    // 1. xl/_rels/workbook.xml.rels → rId → ファイルパス
+    let rels = parse_workbook_rels(&mut archive).unwrap_or_default();
+
+    // 2. xl/workbook.xml → シート名と rId のリスト（順序保持）
+    let sheets = parse_workbook(&mut archive)?;
+
+    // 3. xl/sharedStrings.xml → 共有文字列テーブル（存在しない場合は空）
+    let shared_strings = parse_shared_strings(&mut archive).unwrap_or_default();
+
+    // 4. 各シートを Section に変換
+    let mut sections = Vec::new();
+    for (name, rid) in &sheets {
+        let target = match rels.get(rid.as_str()) {
+            Some(t) => t.clone(),
+            None => {
+                eprintln!(
+                    "Warning: シート '{}' (rId={}) のパスが見つかりません",
+                    name, rid
+                );
+                continue;
+            }
+        };
+
+        // "worksheets/sheet1.xml" → "xl/worksheets/sheet1.xml"
+        let sheet_path = resolve_path(&target);
+
+        match parse_worksheet(&mut archive, &sheet_path, &shared_strings) {
+            Ok(grid) => {
+                let section = sheet_to_section(name, grid, config.xlsx_max_rows);
+                sections.push(section);
+            }
+            Err(e) => {
+                eprintln!("Warning: シート '{}' の解析に失敗しました: {e}", name);
+            }
+        }
+    }
+
+    Ok(Document { title, sections })
+}
+
+/// シート名とグリッドデータから Section を生成する
+///
+/// - `max_rows == 0` またはデータ行数 ≤ max_rows の場合:
+///   フラットな Markdown 表を body_text に格納する。
+/// - データ行数 > max_rows の場合:
+///   親 Section の body_text に概要（行数・チャンク数）を格納し、
+///   ヘッダー行を引き継いだ子 Section に max_rows 行ずつ分割する。
+fn sheet_to_section(name: &str, rows: Vec<Vec<String>>, max_rows: usize) -> Section {
+    if rows.is_empty() {
+        return Section {
+            context_path: Vec::new(),
+            heading: name.to_string(),
+            body_text: String::new(),
+            assets: Vec::new(),
+            children: Vec::new(),
+        };
+    }
+
+    let data_row_count = rows.len().saturating_sub(1); // ヘッダー行を除くデータ行数
+
+    if max_rows == 0 || data_row_count <= max_rows {
+        // 制限なし、または行数が範囲内: フラットに出力
+        return Section {
+            context_path: Vec::new(),
+            heading: name.to_string(),
+            body_text: grid_to_markdown(&rows),
+            assets: Vec::new(),
+            children: Vec::new(),
+        };
+    }
+
+    // データ行数超過: ヘッダー行を保持しながら子 Section に分割
+    let header = rows[0].clone();
+    let data_rows = &rows[1..];
+    let chunk_count = (data_row_count + max_rows - 1) / max_rows;
+
+    let children: Vec<Section> = data_rows
+        .chunks(max_rows)
+        .enumerate()
+        .map(|(i, chunk)| {
+            let start = i * max_rows + 1; // 1-indexed データ行番号
+            let end = start + chunk.len() - 1;
+
+            // 子 Section の body_text: ヘッダー行 + このチャンクのデータ行
+            let mut child_rows = Vec::with_capacity(chunk.len() + 1);
+            child_rows.push(header.clone());
+            child_rows.extend_from_slice(chunk);
+
+            Section {
+                context_path: Vec::new(), // fill_context_path() で後から設定
+                heading: format!("{} [行 {}–{}]", name, start, end),
+                body_text: grid_to_markdown(&child_rows),
+                assets: Vec::new(),
+                children: Vec::new(),
+            }
+        })
+        .collect();
+
+    Section {
+        context_path: Vec::new(),
+        heading: name.to_string(),
+        body_text: format!(
+            "（全 {} 行 / {} 行ずつ {} チャンクに分割）",
+            data_row_count, max_rows, chunk_count
+        ),
+        assets: Vec::new(),
+        children,
+    }
+}
+
+// ---- XML パーサー群 ----
+
+/// `xl/_rels/workbook.xml.rels` を解析して `rId → Target` の Map を返す
+fn parse_workbook_rels(archive: &mut ZipArchive<File>) -> Result<HashMap<String, String>> {
+    let content = read_zip_entry(archive, "xl/_rels/workbook.xml.rels")?;
+    let mut map = HashMap::new();
+
+    let mut reader = Reader::from_str(&content);
+    reader.config_mut().trim_text(true);
+
+    loop {
+        match reader.read_event()? {
+            Event::Empty(e) | Event::Start(e)
+                if e.local_name().as_ref() == b"Relationship" =>
+            {
+                let mut id = String::new();
+                let mut target = String::new();
+                for attr in e.attributes().flatten() {
+                    match attr.key.local_name().as_ref() {
+                        b"Id" => id = decode_bytes(&attr.value),
+                        b"Target" => target = decode_bytes(&attr.value),
+                        _ => {}
+                    }
+                }
+                if !id.is_empty() && !target.is_empty() {
+                    map.insert(id, target);
+                }
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+    Ok(map)
+}
+
+/// `xl/workbook.xml` を解析してシートのリスト `(name, rId)` を順序付きで返す
+fn parse_workbook(archive: &mut ZipArchive<File>) -> Result<Vec<(String, String)>> {
+    let content = read_zip_entry(archive, "xl/workbook.xml")?;
+    let mut sheets = Vec::new();
+
+    let mut reader = Reader::from_str(&content);
+    reader.config_mut().trim_text(true);
+
+    loop {
+        match reader.read_event()? {
+            Event::Empty(e) | Event::Start(e) if e.local_name().as_ref() == b"sheet" => {
+                let mut name = String::new();
+                let mut rid = String::new();
+                for attr in e.attributes().flatten() {
+                    match attr.key.local_name().as_ref() {
+                        b"name" => name = decode_bytes(&attr.value),
+                        // r:id の local_name は "id"
+                        b"id" => rid = decode_bytes(&attr.value),
+                        _ => {}
+                    }
+                }
+                if !name.is_empty() && !rid.is_empty() {
+                    sheets.push((name, rid));
+                }
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+    Ok(sheets)
+}
+
+/// `xl/sharedStrings.xml` を解析して共有文字列テーブルを返す
+///
+/// リッチテキスト（`<si><r><t>...</t></r></si>`）にも対応し、
+/// `<t>` 要素のテキストを順に結合して1エントリとする。
+fn parse_shared_strings(archive: &mut ZipArchive<File>) -> Result<Vec<String>> {
+    let content = read_zip_entry(archive, "xl/sharedStrings.xml")?;
+    let mut strings = Vec::new();
+
+    let mut reader = Reader::from_str(&content);
+    // 空白保持: セル値の先頭・末尾スペースを守るため trim_text を false に
+    reader.config_mut().trim_text(false);
+
+    let mut in_si = false;
+    let mut current = String::new();
+
+    loop {
+        match reader.read_event()? {
+            Event::Start(e) if e.local_name().as_ref() == b"si" => {
+                in_si = true;
+                current.clear();
+            }
+            Event::End(e) if e.local_name().as_ref() == b"si" => {
+                strings.push(current.trim().to_string());
+                in_si = false;
+            }
+            Event::Text(e) if in_si => {
+                current.push_str(&e.unescape().unwrap_or_default());
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+    Ok(strings)
+}
+
+/// `xl/worksheets/sheet*.xml` を解析してセルグリッドを返す
+///
+/// 戻り値: 行×列の密な 2D Vec（空セルは空文字列）
+fn parse_worksheet(
+    archive: &mut ZipArchive<File>,
+    path: &str,
+    shared_strings: &[String],
+) -> Result<Vec<Vec<String>>> {
+    let content = read_zip_entry(archive, path)?;
+    let mut reader = Reader::from_str(&content);
+    reader.config_mut().trim_text(true);
+
+    // スパースグリッド: (row_idx, col_idx) → セル値
+    let mut sparse: HashMap<(usize, usize), String> = HashMap::new();
+    let mut max_row = 0usize;
+    let mut max_col = 0usize;
+
+    // 現在処理中のセル情報
+    let mut cur_row = 0usize;
+    let mut cur_col = 0usize;
+    let mut cell_type = String::new();
+    let mut in_v = false; // <v> 要素内（数値・共有文字列インデックス・式結果）
+    let mut in_t = false; // <t> 要素内（inlineStr）
+    let mut cell_buf = String::new();
+
+    loop {
+        match reader.read_event()? {
+            Event::Start(e) | Event::Empty(e) => {
+                match e.local_name().as_ref() {
+                    b"row" => {
+                        for attr in e.attributes().flatten() {
+                            if attr.key.local_name().as_ref() == b"r" {
+                                let row_num: usize =
+                                    decode_bytes(&attr.value).parse().unwrap_or(1);
+                                cur_row = row_num.saturating_sub(1);
+                                max_row = max_row.max(cur_row + 1);
+                            }
+                        }
+                    }
+                    b"c" => {
+                        cell_type.clear();
+                        cell_buf.clear();
+                        for attr in e.attributes().flatten() {
+                            match attr.key.local_name().as_ref() {
+                                b"r" => {
+                                    let cell_ref = decode_bytes(&attr.value);
+                                    cur_col = col_index(&cell_ref);
+                                    max_col = max_col.max(cur_col + 1);
+                                }
+                                b"t" => cell_type = decode_bytes(&attr.value),
+                                _ => {}
+                            }
+                        }
+                    }
+                    b"v" => in_v = true,
+                    b"t" => in_t = true,
+                    _ => {}
+                }
+            }
+            Event::End(e) => match e.local_name().as_ref() {
+                b"v" => in_v = false,
+                b"t" => in_t = false,
+                b"c" => {
+                    // セル値を確定してスパースグリッドに格納
+                    let val = resolve_cell_value(&cell_type, &cell_buf, shared_strings);
+                    if !val.is_empty() {
+                        sparse.insert((cur_row, cur_col), val);
+                    }
+                }
+                _ => {}
+            },
+            Event::Text(e) if in_v || in_t => {
+                cell_buf.push_str(&e.unescape().unwrap_or_default());
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+
+    // スパースグリッド → 密な 2D Vec
+    if max_row == 0 || max_col == 0 {
+        return Ok(Vec::new());
+    }
+    let mut grid = vec![vec![String::new(); max_col]; max_row];
+    for ((r, c), val) in sparse {
+        grid[r][c] = val;
+    }
+    Ok(grid)
+}
+
+/// セルの型と生の値から表示文字列を返す
+///
+/// | `t` 属性 | 意味 | 処理 |
+/// |----------|------|------|
+/// | `"s"`    | 共有文字列インデックス | shared_strings テーブルを引く |
+/// | `"b"`    | 真偽値 | "1" → "TRUE", それ以外 → "FALSE" |
+/// | `"e"`    | エラー (#DIV/0! 等) | 生値そのまま |
+/// | 省略     | 数値・文字列式結果 | trim して返す |
+fn resolve_cell_value(cell_type: &str, raw: &str, shared_strings: &[String]) -> String {
+    match cell_type {
+        "s" => raw
+            .trim()
+            .parse::<usize>()
+            .ok()
+            .and_then(|i| shared_strings.get(i))
+            .cloned()
+            .unwrap_or_default(),
+        "b" => {
+            if raw == "1" {
+                "TRUE".to_string()
+            } else {
+                "FALSE".to_string()
+            }
+        }
+        "e" => raw.to_string(),
+        _ => raw.trim().to_string(),
+    }
+}
+
+// ---- Markdown 生成 ----
+
+/// セルグリッドを Markdown 表に変換する
+///
+/// - 先頭行をヘッダーとして扱い、2行目にセパレータ（`|---|`）を挿入する
+/// - 列数はグリッド内の最大列数に揃える
+fn grid_to_markdown(rows: &[Vec<String>]) -> String {
+    if rows.is_empty() {
+        return String::new();
+    }
+    let col_count = rows.iter().map(|r| r.len()).max().unwrap_or(0);
+    if col_count == 0 {
+        return String::new();
+    }
+
+    let mut out = String::new();
+    for (i, row) in rows.iter().enumerate() {
+        let cells: Vec<String> = (0..col_count)
+            .map(|c| row.get(c).map(|s| escape_cell(s)).unwrap_or_default())
+            .collect();
+        out.push_str(&format!("| {} |\n", cells.join(" | ")));
+        if i == 0 {
+            // ヘッダー直後にセパレータ行を挿入
+            let sep = vec!["---"; col_count];
+            out.push_str(&format!("|{}|\n", sep.join("|")));
+        }
+    }
+    out
+}
+
+/// Markdown テーブルセル内の特殊文字をエスケープする
+fn escape_cell(s: &str) -> String {
+    s.replace('|', "\\|")
+        .replace('\n', " ")
+        .replace('\r', "")
+}
+
+// ---- ユーティリティ ----
+
+/// セル参照（"A1"、"AB12" 等）からゼロ始まりの列インデックスを返す
+///
+/// A=0, B=1, …, Z=25, AA=26, AB=27, …
+fn col_index(cell_ref: &str) -> usize {
+    cell_ref
+        .chars()
+        .take_while(|c| c.is_ascii_alphabetic())
+        .fold(0usize, |acc, c| {
+            acc * 26 + (c.to_ascii_uppercase() as usize - b'A' as usize + 1)
+        })
+        .saturating_sub(1)
+}
+
+/// `xl/_rels/workbook.xml.rels` の Target パスを ZIP 内絶対パスに解決する
+///
+/// - 絶対パス（`/xl/worksheets/sheet1.xml`）→ 先頭スラッシュを除去
+/// - 相対パス（`worksheets/sheet1.xml`）→ `xl/` を前置
+fn resolve_path(target: &str) -> String {
+    if target.starts_with('/') {
+        target.trim_start_matches('/').to_string()
+    } else {
+        format!("xl/{}", target)
+    }
+}
+
+/// `Cow<[u8]>` を UTF-8 文字列にデコードする
+fn decode_bytes(val: &[u8]) -> String {
+    String::from_utf8_lossy(val).into_owned()
+}
+
+/// ZIPアーカイブから指定パスのエントリを文字列として読み出す
+fn read_zip_entry(archive: &mut ZipArchive<File>, name: &str) -> Result<String> {
+    let mut entry = archive
+        .by_name(name)
+        .with_context(|| format!("ZIPエントリが見つかりません: {name}"))?;
+    let mut buf = String::new();
+    entry
+        .read_to_string(&mut buf)
+        .with_context(|| format!("ZIPエントリの読み込みに失敗: {name}"))?;
+    Ok(buf)
 }


### PR DESCRIPTION
## Summary

- **ZIPストリームパース**: `workbook.xml` / `sharedStrings.xml` / `sheet*.xml` を順番に解析
- **セル型への対応**: Shared Strings（`t="s"`）・inlineStr（`t="inlineStr"`）・真偽値（`t="b"`）・エラー値（`t="e"`）・数値
- **Markdownテーブル生成**: 先頭行をヘッダーとして `| header | ... |` 形式に変換
- **大規模表のチャンク分割**: `xlsx_max_rows` 超過時にヘッダーを引き継いだ子Sectionへ分割
  - `--split 2` と組み合わせることでチャンクごとに個別JSONファイルを出力（RAG向け）

## 新設定・CLI引数

| 追加項目 | 説明 |
|----------|------|
| `config.xlsx_max_rows` | シートあたりの最大データ行数（0=無制限） |
| `--xlsx-max-rows <N>` | CLI引数（設定ファイルより優先） |

## 出力例（`--xlsx-max-rows 5` 指定時）

```json
{
  "heading": "経費精算",
  "body_text": "（全 1200 行 / 5 行ずつ 240 チャンクに分割）",
  "children": [
    {
      "heading": "経費精算 [行 1–5]",
      "context_path": ["経費精算", "経費精算 [行 1–5]"],
      "body_text": "| 日付 | 項目 | 金額 |\n|---|---|---|\n| ... |"
    }
  ]
}
```

## Test plan

- [ ] `cargo build` が警告ゼロで通る
- [ ] サンプルXLSXで sections・body_text が正しく生成される
- [ ] `--xlsx-max-rows 5` で children に正しく分割される
- [ ] 各 child の `context_path` にシート名が引き継がれる
- [ ] `--xlsx-max-rows 5 --split 2` でチャンクごとに個別JSONが出力される

🤖 Generated with [Claude Code](https://claude.com/claude-code)