### PR TITLE
fix: --split の Chunk に children を追加し子セクションの階層構造を保持 (#16)

### DIFF
--- a/src/splitter.rs
+++ b/src/splitter.rs
@@ -1,7 +1,7 @@
 /// RAG向けチャンク分割
 ///
 /// セクションツリーを指定した深さで分割し、各チャンクを個別 JSON ファイルとして出力する。
-/// 子セクションの本文は Markdown 見出しとして上位チャンクに統合される。
+/// 子セクションは `children` フィールドに再帰的に保持される（body_text へのフラット化は行わない）。
 use std::path::Path;
 
 use anyhow::{Context, Result};
@@ -9,7 +9,7 @@ use serde::Serialize;
 
 use crate::models::{Asset, Document, Section};
 
-/// 分割後の単一チャンク（RAG インジェスト向けフラット構造）
+/// 分割後の単一チャンク（RAG インジェスト向け構造）
 #[derive(Debug, Serialize)]
 pub struct Chunk {
     /// 元のドキュメントタイトル（ファイル名）
@@ -18,10 +18,12 @@ pub struct Chunk {
     pub context_path: Vec<String>,
     /// このチャンクのトップ見出し
     pub heading: String,
-    /// 子セクションの本文を Markdown 見出しとして統合済みの本文
+    /// このセクション直下の本文（子セクションの内容は含まない）
     pub body_text: String,
-    /// 子セクションのアセットを含む全アセット
+    /// このセクション直下のアセット
     pub assets: Vec<Asset>,
+    /// 子セクションのチャンク（再帰的）
+    pub children: Vec<Chunk>,
 }
 
 /// Document をチャンクに分割して個別 JSON ファイルへ書き出す
@@ -63,7 +65,6 @@ pub fn write_chunks(
             .context("チャンクのJSONシリアライズに失敗")?;
         std::fs::write(&out_path, &json)
             .with_context(|| format!("チャンクファイルへの書き込みに失敗: {}", out_path.display()))?;
-        // 出力先の表示は main.rs の結果サマリーで一括表示するため ここでは省略
     }
 
     Ok(())
@@ -72,7 +73,7 @@ pub fn write_chunks(
 /// セクションツリーを再帰的に走査し、指定深さのチャンクを収集する
 ///
 /// `current_depth >= split_level` または葉ノード（children が空）のセクションを
-/// チャンク化の起点とする。その配下の子セクションは `flatten_into` で本文に統合する。
+/// チャンク化の起点とする。その配下の子セクションは `children` フィールドに再帰的に保持する。
 fn collect_chunks(
     sections: &[Section],
     source: &str,
@@ -83,17 +84,8 @@ fn collect_chunks(
     for section in sections {
         if current_depth >= split_level || section.children.is_empty() {
             // このセクションをチャンクの起点とする
-            let mut body_text = section.body_text.clone();
-            let mut assets = section.assets.clone();
-            // 子セクションを Markdown 見出し付きで body_text に統合
-            flatten_into(&section.children, &mut body_text, &mut assets, 2);
-            chunks.push(Chunk {
-                source: source.to_string(),
-                context_path: section.context_path.clone(),
-                heading: section.heading.clone(),
-                body_text,
-                assets,
-            });
+            // 子セクションは children フィールドに再帰的に保持（body_text へのフラット化は行わない）
+            chunks.push(section_to_chunk(section, source));
         } else {
             // まだ目標の深さに達していない: 子を再帰的に収集
             chunks.extend(collect_chunks(
@@ -107,34 +99,16 @@ fn collect_chunks(
     chunks
 }
 
-/// セクションリストを再帰的に走査して body_text・assets に平坦化する
-///
-/// 各セクションの見出しは Markdown 見出し記法（## / ### …）で挿入する
-fn flatten_into(
-    sections: &[Section],
-    body_text: &mut String,
-    assets: &mut Vec<Asset>,
-    heading_depth: usize,
-) {
-    for section in sections {
-        // 見出しを Markdown 形式で挿入
-        if !section.heading.is_empty() {
-            let hashes = "#".repeat(heading_depth.min(6));
-            if !body_text.is_empty() {
-                body_text.push('\n');
-            }
-            body_text.push_str(&format!("\n{} {}\n", hashes, section.heading));
-        }
-        // 本文を追記
-        if !section.body_text.is_empty() {
-            if !body_text.is_empty() && !body_text.ends_with('\n') {
-                body_text.push('\n');
-            }
-            body_text.push_str(&section.body_text);
-        }
-        // アセットを収集
-        assets.extend_from_slice(&section.assets);
-        // 孫以下を再帰的に処理
-        flatten_into(&section.children, body_text, assets, heading_depth + 1);
+/// Section を Chunk に変換する（子セクションも再帰的に Chunk 化）
+fn section_to_chunk(section: &Section, source: &str) -> Chunk {
+    Chunk {
+        source: source.to_string(),
+        context_path: section.context_path.clone(),
+        heading: section.heading.clone(),
+        body_text: section.body_text.clone(),
+        assets: section.assets.clone(),
+        children: section.children.iter()
+            .map(|c| section_to_chunk(c, source))
+            .collect(),
     }
 }


### PR DESCRIPTION
## 概要

Issue #16「docxのパースの際にChildrenが入っていない」の修正。

## 根本原因の分析

DOCXパーサー自体（`docx.rs`）は正常に `Section.children` を構築していました。問題は `splitter.rs` にあり、`--split` モードで出力する `Chunk` 構造体に `children` フィールドが存在しなかったため、`flatten_into` によって子セクションの内容が `body_text` に埋め込まれていました。

**修正前** (`--split 1` の `chunk_004.json`):
```json
{
  "heading": "２　委託内容",
  "body_text": "\n## 2.1　委託する作業の内容\n...\n## 2.2　成果物\n...",
  "assets": []
}
```

**修正後** (`--split 1` の `chunk_004.json`):
```json
{
  "heading": "２　委託内容",
  "body_text": "",
  "assets": [],
  "children": [
    { "heading": "2.1　委託する作業の内容", "body_text": "委託内容は以下のとおり。...", "children": [] },
    { "heading": "2.2　成果物", "body_text": "本業務の成果物は...", "children": [] }
  ]
}
```

## 変更内容

### `src/splitter.rs`

- `Chunk` 構造体に `children: Vec<Chunk>` フィールドを追加
- `flatten_into` 関数を削除
- `section_to_chunk` ヘルパー関数を追加（子セクションを再帰的に `Chunk` 化）
- `collect_chunks` の子処理を `section_to_chunk` に委譲

## テスト確認

```bash
cargo run -- --input ./samples/shiyousho_sample_untenkanshi.docx --output ./out/test --split 1
```

- チャンクファイル数: 8個（`--split 1` で 8 つの最上位セクション）
- `chunk_004.json`: `body_text=""`, `children=[{2.1...}, {2.2...}]` ✓
- `chunk_006.json`: `children=[4.1(5子), 4.2, 4.3]` ✓（3階層も正常）

🤖 Generated with [Claude Code](https://claude.com/claude-code)