### PR TITLE
feat: inspect-styles サブコマンドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ AIによる文書解析（RAGや要約）の精度を最大化するため、単
 | **意味的役割（SemanticRole）** | ✅ | スタイル名から `Warning` / `Note` / `Tip` / `CodeBlock` / `Quote` 等を自動推定し `elements[].metadata.role` に付与。日本語スタイル名にも対応。 |
 | **カスタム SemanticRole マッピング** | ✅ | `docx.semantic_role_styles` でスタイル名 → SemanticRole を設定ファイルから外部注入可能。 |
 | **出力フィールド制御** | ✅ | `output.include_body_text`（デフォルト: `false`）と `output.include_base64`（デフォルト: `true`）で JSON サイズを最適化。 |
+| **見出しスタイル検査** | ✅ | `inspect-styles` サブコマンド。DOCX の `word/styles.xml` を走査し、見出しスタイル一覧と `docx2json.json` 用 `heading_styles` 設定スニペットを JSON で出力。 |
 
 ## 🛠 技術スタック
 | カテゴリ | ライブラリ | 選定理由 |
@@ -122,6 +123,52 @@ cargo run -- parse --dump-config > docx2json.json
 | `--image-quality <Q>` | — | `80` | `image.quality` | JPEG 品質（1〜100）。設定ファイルより優先 |
 | `--xlsx-max-rows <N>` | — | `0`（無効） | `xlsx.max_rows` | XLSX シートの最大行数。設定ファイルより優先 |
 | `--dump-config` | — | — | — | 実効設定（設定ファイル + CLI 引数の適用後）を JSON で出力して終了 |
+
+### `inspect-styles` — DOCX 見出しスタイル検査
+
+カスタムスタイルを使っている DOCX をパースする前に、どのスタイル名が見出しとして定義されているかを確認できます。
+出力された `docx.heading_styles` は `docx2json.json` にそのまま貼り付けて使用できます。
+
+```bash
+# 標準出力に JSON を表示（stderr に検出サマリー）
+docx2json inspect-styles --input ./sample.docx
+
+# ファイルに書き出す
+docx2json inspect-styles --input ./sample.docx --output ./heading_config.json
+```
+
+**出力例（stdout）:**
+```json
+{
+  "docx": {
+    "heading_styles": {
+      "1": 1,
+      "heading 1": 1,
+      "2": 2,
+      "heading 2": 2,
+      "3": 3,
+      "heading 3": 3
+    }
+  },
+  "styles": [
+    { "style_id": "1", "name": "heading 1", "level": 1 },
+    { "style_id": "2", "name": "heading 2", "level": 2 },
+    { "style_id": "3", "name": "heading 3", "level": 3 }
+  ]
+}
+```
+
+**出力フィールド:**
+
+| フィールド | 説明 |
+| :--- | :--- |
+| `docx.heading_styles` | `docx2json.json` に貼り付けられる設定スニペット。`styleId` と表示名の両方をキーとして収録 |
+| `styles[].style_id` | XML 内部の `w:styleId`（`w:pStyle` で参照される識別子） |
+| `styles[].name` | Word 上の表示スタイル名（`w:name w:val`） |
+| `styles[].level` | 見出しレベル（1〜9）。`w:outlineLvl` の値 + 1 |
+
+> **ヒント:** `inspect-styles` で検出されなかった場合は、そのファイルが Word 標準の見出しスタイルを使っていない可能性があります。
+> `ppr_underline_as_heading` や `run_underline_as_heading` の設定を検討してください。
 
 ### AI・ワークフロー連携コマンド
 
@@ -417,5 +464,6 @@ src/
     ├── mod.rs               # サブコマンドモジュール宣言
     ├── extract_candidates.rs # LLM 向け候補テキスト抽出（→ JSONL）
     ├── inject_tags.rs        # AI タグ注入 + keywords.json バリデーション
+    ├── inspect_styles.rs     # DOCX 見出しスタイル検査（→ heading_styles 設定スニペット）
     └── summarize.rs          # タグ使用統計横断集計（→ tags_summary.json）
 ```

--- a/src/commands/inspect_styles.rs
+++ b/src/commands/inspect_styles.rs
@@ -1,0 +1,200 @@
+use std::collections::HashMap;
+use std::io::BufReader;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use quick_xml::events::Event;
+use quick_xml::reader::Reader;
+use serde::Serialize;
+use zip::ZipArchive;
+
+/// `inspect-styles` サブコマンドの引数
+#[derive(clap::Args)]
+pub struct Args {
+    /// 解析する DOCX ファイルのパス
+    #[arg(long)]
+    pub input: PathBuf,
+
+    /// 出力先ファイルパス（省略時は標準出力）
+    #[arg(long)]
+    pub output: Option<PathBuf>,
+}
+
+#[derive(Debug)]
+struct StyleEntry {
+    style_id: String,
+    name: String,
+    outline_lvl: usize, // 0-based (0 = レベル1)
+}
+
+/// stdout / ファイルに出力する JSON 構造
+#[derive(Serialize)]
+struct InspectOutput {
+    /// docx2json.json にそのまま貼り付けられる設定スニペット
+    docx: DocxSnippet,
+    /// スタイル詳細（参考情報）
+    styles: Vec<StyleDetail>,
+}
+
+#[derive(Serialize)]
+struct DocxSnippet {
+    heading_styles: HashMap<String, usize>,
+}
+
+#[derive(Serialize)]
+struct StyleDetail {
+    style_id: String,
+    name: String,
+    level: usize,
+}
+
+pub fn run(args: Args) -> Result<()> {
+    let path = &args.input;
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+    if !matches!(ext, "docx") {
+        anyhow::bail!("DOCX ファイルを指定してください（拡張子が .docx であること）: {}", path.display());
+    }
+
+    let styles = parse_styles_xml(path)
+        .with_context(|| format!("styles.xml のパースに失敗: {}", path.display()))?;
+
+    if styles.is_empty() {
+        eprintln!("見出しスタイル（outlineLvl 付き）は検出されませんでした。");
+        eprintln!("ヒント: このファイルは Word 標準の見出しスタイルを使用していない可能性があります。");
+        eprintln!("       代わりに --config で ppr_underline_as_heading や run_underline_as_heading を試してください。");
+        return Ok(());
+    }
+
+    // heading_styles マップ: styleId と name の両方をキーとして登録（重複時は1エントリ）
+    let mut heading_styles: HashMap<String, usize> = HashMap::new();
+    let mut style_details: Vec<StyleDetail> = Vec::new();
+
+    eprintln!("見出しスタイルを {} 件検出: {}", styles.len(), path.display());
+    for entry in &styles {
+        let level = entry.outline_lvl + 1;
+        eprintln!("  Level {}: {:?}  (style_id: {:?})", level, entry.name, entry.style_id);
+
+        heading_styles.insert(entry.style_id.clone(), level);
+        if entry.name != entry.style_id {
+            heading_styles.insert(entry.name.clone(), level);
+        }
+        style_details.push(StyleDetail {
+            style_id: entry.style_id.clone(),
+            name: entry.name.clone(),
+            level,
+        });
+    }
+
+    let out = InspectOutput {
+        docx: DocxSnippet { heading_styles },
+        styles: style_details,
+    };
+    let json = serde_json::to_string_pretty(&out)?;
+
+    match &args.output {
+        Some(out_path) => {
+            std::fs::write(out_path, &json)
+                .with_context(|| format!("出力ファイルの書き込みに失敗: {}", out_path.display()))?;
+            eprintln!("設定スニペットを書き出しました → {}", out_path.display());
+        }
+        None => println!("{}", json),
+    }
+
+    Ok(())
+}
+
+/// word/styles.xml をパースして outlineLvl を持つ段落スタイルを返す
+fn parse_styles_xml(docx_path: &PathBuf) -> Result<Vec<StyleEntry>> {
+    let file = std::fs::File::open(docx_path)
+        .with_context(|| format!("ファイルを開けません: {}", docx_path.display()))?;
+    let mut archive = ZipArchive::new(BufReader::new(file))
+        .context("ZIPアーカイブとして開けません（破損または非 DOCX ファイルの可能性）")?;
+
+    let xml = {
+        let mut entry = archive
+            .by_name("word/styles.xml")
+            .context("word/styles.xml が見つかりません")?;
+        let mut buf = String::new();
+        std::io::Read::read_to_string(&mut entry, &mut buf)
+            .context("word/styles.xml の読み込みに失敗")?;
+        buf
+    };
+
+    let mut reader = Reader::from_str(&xml);
+    reader.config_mut().trim_text(true);
+
+    let mut styles: Vec<StyleEntry> = Vec::new();
+    let mut current_id: Option<String> = None;
+    let mut is_paragraph: bool = false;
+    let mut current_name: Option<String> = None;
+    let mut current_lvl: Option<usize> = None;
+    let mut in_style = false;
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e)) => {
+                match e.local_name().as_ref() {
+                    b"style" => {
+                        in_style = true;
+                        current_id = attr_value(e, "styleId");
+                        is_paragraph = attr_value(e, "type").as_deref() == Some("paragraph");
+                        current_name = None;
+                        current_lvl = None;
+                    }
+                    b"name" if in_style => {
+                        if let Some(val) = attr_value(e, "val") {
+                            current_name = Some(val);
+                        }
+                    }
+                    b"outlineLvl" if in_style => {
+                        if let Some(val) = attr_value(e, "val") {
+                            if let Ok(n) = val.parse::<usize>() {
+                                // outlineLvl 9 はボディテキスト扱い（見出しではない）
+                                if n < 9 {
+                                    current_lvl = Some(n);
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            Ok(Event::End(ref e)) if e.local_name().as_ref() == b"style" => {
+                if in_style && is_paragraph {
+                    if let (Some(id), Some(name), Some(lvl)) =
+                        (current_id.take(), current_name.take(), current_lvl.take())
+                    {
+                        styles.push(StyleEntry {
+                            style_id: id,
+                            name,
+                            outline_lvl: lvl,
+                        });
+                    }
+                }
+                // いずれにせよリセット
+                current_id = None;
+                current_name = None;
+                current_lvl = None;
+                is_paragraph = false;
+                in_style = false;
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => return Err(anyhow::Error::from(e)),
+            _ => {}
+        }
+    }
+
+    styles.sort_by_key(|s| s.outline_lvl);
+    Ok(styles)
+}
+
+/// XML 要素から属性値を取得する（名前空間プレフィックスを無視）
+fn attr_value(e: &quick_xml::events::BytesStart, name: &str) -> Option<String> {
+    let local = name.split(':').next_back().unwrap_or(name);
+    for attr in e.attributes().flatten() {
+        if attr.key.local_name().as_ref() == local.as_bytes() {
+            return String::from_utf8(attr.value.to_vec()).ok();
+        }
+    }
+    None
+}

--- a/src/commands/inspect_styles.rs
+++ b/src/commands/inspect_styles.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::io::BufReader;
 use std::path::PathBuf;
 
@@ -7,6 +7,8 @@ use quick_xml::events::Event;
 use quick_xml::reader::Reader;
 use serde::Serialize;
 use zip::ZipArchive;
+
+use crate::parser::attr_value;
 
 /// `inspect-styles` サブコマンドの引数
 #[derive(clap::Args)]
@@ -38,7 +40,7 @@ struct InspectOutput {
 
 #[derive(Serialize)]
 struct DocxSnippet {
-    heading_styles: HashMap<String, usize>,
+    heading_styles: BTreeMap<String, usize>,
 }
 
 #[derive(Serialize)]
@@ -50,8 +52,8 @@ struct StyleDetail {
 
 pub fn run(args: Args) -> Result<()> {
     let path = &args.input;
-    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-    if !matches!(ext, "docx") {
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("").to_ascii_lowercase();
+    if ext != "docx" {
         anyhow::bail!("DOCX ファイルを指定してください（拡張子が .docx であること）: {}", path.display());
     }
 
@@ -66,7 +68,7 @@ pub fn run(args: Args) -> Result<()> {
     }
 
     // heading_styles マップ: styleId と name の両方をキーとして登録（重複時は1エントリ）
-    let mut heading_styles: HashMap<String, usize> = HashMap::new();
+    let mut heading_styles: BTreeMap<String, usize> = BTreeMap::new();
     let mut style_details: Vec<StyleDetail> = Vec::new();
 
     eprintln!("見出しスタイルを {} 件検出: {}", styles.len(), path.display());
@@ -146,6 +148,9 @@ fn parse_styles_xml(docx_path: &PathBuf) -> Result<Vec<StyleEntry>> {
                             current_name = Some(val);
                         }
                     }
+                    // TODO: basedOn によるスタイル継承（親が outlineLvl を持ち子が上書きしない場合）は
+                    //       現在未対応。日本語テンプレートでカスタムスタイルが見出しを継承している
+                    //       場合に検出されないことがある。
                     b"outlineLvl" if in_style => {
                         if let Some(val) = attr_value(e, "val") {
                             if let Ok(n) = val.parse::<usize>() {
@@ -188,13 +193,3 @@ fn parse_styles_xml(docx_path: &PathBuf) -> Result<Vec<StyleEntry>> {
     Ok(styles)
 }
 
-/// XML 要素から属性値を取得する（名前空間プレフィックスを無視）
-fn attr_value(e: &quick_xml::events::BytesStart, name: &str) -> Option<String> {
-    let local = name.split(':').next_back().unwrap_or(name);
-    for attr in e.attributes().flatten() {
-        if attr.key.local_name().as_ref() == local.as_bytes() {
-            return String::from_utf8(attr.value.to_vec()).ok();
-        }
-    }
-    None
-}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod extract_candidates;
 pub mod inject_tags;
+pub mod inspect_styles;
 pub mod summarize;

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,8 @@ enum Commands {
     ExtractCandidates(commands::extract_candidates::Args),
     /// セクションに AI タグを注入してバリデーションする
     InjectTags(commands::inject_tags::Args),
+    /// DOCX ファイルの見出しスタイルを走査して docx2json.json 用設定スニペットを出力する
+    InspectStyles(commands::inspect_styles::Args),
     /// 複数の document.json からタグ使用統計を集計する
     Summarize(commands::summarize::Args),
 }
@@ -94,6 +96,12 @@ fn main() {
         }
         Some(Commands::InjectTags(args)) => {
             if let Err(e) = commands::inject_tags::run(args) {
+                eprintln!("Error: {e:#}");
+                std::process::exit(1);
+            }
+        }
+        Some(Commands::InspectStyles(args)) => {
+            if let Err(e) = commands::inspect_styles::run(args) {
                 eprintln!("Error: {e:#}");
                 std::process::exit(1);
             }

--- a/src/parser/docx.rs
+++ b/src/parser/docx.rs
@@ -998,17 +998,7 @@ fn determine_role(style: &str, config: &DocxConfig) -> Option<SemanticRole> {
     }
 }
 
-/// XML要素から属性値を取得する（名前空間プレフィックスを無視）
-fn attr_value(e: &quick_xml::events::BytesStart, name: &str) -> Option<String> {
-    let local = name.split(':').next_back().unwrap_or(name);
-    for attr in e.attributes().flatten() {
-        let key = attr.key.local_name();
-        if key.as_ref() == local.as_bytes() {
-            return String::from_utf8(attr.value.to_vec()).ok();
-        }
-    }
-    None
-}
+use super::attr_value;
 
 #[cfg(test)]
 mod tests {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -66,6 +66,19 @@ fn fill_section_id(sections: &mut Vec<Section>, title: &str) {
     }
 }
 
+/// XML 要素から属性値を取得する（名前空間プレフィックスを無視してローカル名で検索）。
+///
+/// `name` に ":" が含まれる場合は最後の部分をローカル名として使用する。
+pub(crate) fn attr_value(e: &quick_xml::events::BytesStart, name: &str) -> Option<String> {
+    let local = name.split(':').next_back().unwrap_or(name);
+    for attr in e.attributes().flatten() {
+        if attr.key.local_name().as_ref() == local.as_bytes() {
+            return String::from_utf8(attr.value.to_vec()).ok();
+        }
+    }
+    None
+}
+
 /// 文字列の FNV-1a 64bit ハッシュを 16文字の 16進数文字列として返す。
 fn fnv1a_hex(s: &str) -> String {
     const FNV_OFFSET: u64 = 14695981039346656037;

--- a/src/parser/pptx.rs
+++ b/src/parser/pptx.rs
@@ -551,19 +551,7 @@ fn resize_and_compress(data: &[u8], max_px: u32, quality: u8) -> Option<Vec<u8>>
     Some(output)
 }
 
-/// XML要素から属性値を取得する（名前空間プレフィックスを無視してローカル名で検索）
-///
-/// name に ":" が含まれる場合は最後の部分をローカル名として使用する。
-/// ただし "r:embed" など異なる prefix を持つ同名属性が存在しないことが前提。
-fn attr_value(e: &quick_xml::events::BytesStart, name: &str) -> Option<String> {
-    let local = name.split(':').next_back().unwrap_or(name);
-    for attr in e.attributes().flatten() {
-        if attr.key.local_name().as_ref() == local.as_bytes() {
-            return String::from_utf8(attr.value.to_vec()).ok();
-        }
-    }
-    None
-}
+use super::attr_value;
 
 /// 名前空間プレフィックスとローカル名を両方指定して属性値を取得する
 ///


### PR DESCRIPTION
## Summary

- `docx2json inspect-styles --input <file.docx>` コマンドを追加
- `word/styles.xml` の `w:outlineLvl` を読み取り、見出しスタイルを自動検出
- `docx2json.json` にそのまま貼り付けられる `heading_styles` 設定スニペットを JSON で出力
- `styleId` と表示名（`w:name`）の両方をキーとして収録するため、どちらの識別子が使われているファイルでも設定がマッチする

## Usage

```bash
# 標準出力に JSON を表示（stderr に検出サマリー）
docx2json inspect-styles --input ./sample.docx

# ファイルに書き出す
docx2json inspect-styles --input ./sample.docx --output ./heading_config.json
```

## Output example

```json
{
  "docx": {
    "heading_styles": {
      "1": 1,
      "heading 1": 1,
      "2": 2,
      "heading 2": 2,
      "3": 3,
      "heading 3": 3
    }
  },
  "styles": [
    { "style_id": "1", "name": "heading 1", "level": 1 },
    { "style_id": "2", "name": "heading 2", "level": 2 },
    { "style_id": "3", "name": "heading 3", "level": 3 }
  ]
}
```

## Test plan

- [ ] 日本語 DOCX（`shiyousho_sample_untenkanshi.docx`）で Level 1-3 が検出されること
- [ ] 見出しスタイルがない DOCX でヒントメッセージが表示されること
- [ ] `.docx` 以外のファイルを指定するとエラーになること
- [ ] `--output` オプションでファイル書き出しが動作すること
- [ ] `cargo build` がエラーなく通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)